### PR TITLE
施設を生成し、ゲームマネージャーに保存する処理

### DIFF
--- a/Assets/FortressFableProject/Program/Scripts/FortressFableScene/FactoryFactory.meta
+++ b/Assets/FortressFableProject/Program/Scripts/FortressFableScene/FactoryFactory.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7e79a455cb42a84408bf271c15b1b1a4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/FortressFableProject/Program/Scripts/FortressFableScene/FactoryFactory/Camp.cs
+++ b/Assets/FortressFableProject/Program/Scripts/FortressFableScene/FactoryFactory/Camp.cs
@@ -1,0 +1,12 @@
+using UnityEngine;
+
+/// <summary>
+/// キャンプ
+/// </summary>
+public class Camp : FactoryBase
+{
+    public override void Effect()
+    {
+        throw new System.NotImplementedException();
+    }
+}

--- a/Assets/FortressFableProject/Program/Scripts/FortressFableScene/FactoryFactory/Camp.cs.meta
+++ b/Assets/FortressFableProject/Program/Scripts/FortressFableScene/FactoryFactory/Camp.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2f7b48934dee7f042bfa742fe3d6227d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/FortressFableProject/Program/Scripts/FortressFableScene/FactoryFactory/FactoryBase.cs
+++ b/Assets/FortressFableProject/Program/Scripts/FortressFableScene/FactoryFactory/FactoryBase.cs
@@ -1,0 +1,10 @@
+using UnityEngine;
+
+public abstract class FactoryBase : MonoBehaviour, IConstruction
+{
+    public virtual void Build()
+    {
+    }
+
+    public abstract void Effect();
+}

--- a/Assets/FortressFableProject/Program/Scripts/FortressFableScene/FactoryFactory/FactoryBase.cs.meta
+++ b/Assets/FortressFableProject/Program/Scripts/FortressFableScene/FactoryFactory/FactoryBase.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 78ade24ab9ad3034eb83c1788747a4d3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/FortressFableProject/Program/Scripts/FortressFableScene/FactoryFactory/FactoryFactory.cs
+++ b/Assets/FortressFableProject/Program/Scripts/FortressFableScene/FactoryFactory/FactoryFactory.cs
@@ -1,0 +1,35 @@
+using UnityEngine;
+
+/// <summary>
+/// 施設を生成する処理を持つ
+/// </summary>
+public class FactoryFactory : MonoBehaviour
+{
+    [Header("鉱山のプレハブ"), SerializeField] [Tooltip("鉱山のプレハブ")]
+    GameObject _minePrefab = default;
+
+    /// <summary>
+    /// ユニットを生成するメソッド 戻り値：IConstruction
+    /// </summary>
+    /// <param name="type"></param>
+    /// <param name="list"></param>
+    /// <returns></returns>
+    public GameObject CreateFactory(FacilityBase.FacilityType type)
+    {
+        GameObject prefab = null;
+        switch (type)
+        {
+            // 鉱山
+            case FacilityBase.FacilityType.Mine:
+                prefab = _minePrefab;
+                break;
+            default:
+                Debug.LogError($"Unknown factory type: {type}");
+                return null;
+        }
+
+        var go = Instantiate(prefab);
+
+        return go;
+    }
+}

--- a/Assets/FortressFableProject/Program/Scripts/FortressFableScene/FactoryFactory/FactoryFactory.cs.meta
+++ b/Assets/FortressFableProject/Program/Scripts/FortressFableScene/FactoryFactory/FactoryFactory.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6dd85fa28c278ea4e9b486854f49128a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/FortressFableProject/Program/Scripts/FortressFableScene/FactoryFactory/FactoryManager.cs
+++ b/Assets/FortressFableProject/Program/Scripts/FortressFableScene/FactoryFactory/FactoryManager.cs
@@ -1,0 +1,44 @@
+using CookieClickerProject.Common;
+using FortressFableProject.Program.Scripts.Common.Core;
+using UnityEngine;
+
+/// <summary>
+/// タイプ別で生成する施設を変える
+/// 生成したものをゲームマネージャーに保存している
+/// </summary>
+public class FactoryManager : AbstractSingleton<FactoryManager>
+{
+    [Header("FactoryFactory"), SerializeField]
+    FactoryFactory _factoryFactory = default;
+
+    [Tooltip("ゲームマネージャー")] GameManager _gameManager = default;
+
+    void Start()
+    {
+        _gameManager = FindObjectOfType<GameManager>();
+    }
+
+    /// <summary>
+    /// タイプに合わせて生成する施設を変える
+    /// </summary>
+    /// <param name="buildingType"> 施設のタイプ </param>
+    /// オブジェクトを返す 建設側で位置を設定する必要がある
+    public GameObject FactoryBuilding(FacilityBase.FacilityType buildingType)
+    {
+        GameObject go = null;
+        switch (buildingType)
+        {
+            // 鉱山
+            case FacilityBase.FacilityType.Mine:
+                go = _factoryFactory.CreateFactory(buildingType);
+                // GameManagerに保存
+                _gameManager.AddFacility(go.GetComponent<FacilityBase>());
+                break;
+            default:
+                Debug.LogError($"Unknown facilityType type: {buildingType}");
+                return null;
+        }
+
+        return go;
+    }
+}

--- a/Assets/FortressFableProject/Program/Scripts/FortressFableScene/FactoryFactory/FactoryManager.cs.meta
+++ b/Assets/FortressFableProject/Program/Scripts/FortressFableScene/FactoryFactory/FactoryManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3d2fd9dac9e321a4db8345600e7f3ca8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/FortressFableProject/Program/Scripts/FortressFableScene/FactoryFactory/TrainingFacility.cs
+++ b/Assets/FortressFableProject/Program/Scripts/FortressFableScene/FactoryFactory/TrainingFacility.cs
@@ -1,0 +1,12 @@
+using UnityEngine;
+
+/// <summary>
+/// 兵舎
+/// </summary>
+public class TrainingFacility : FactoryBase
+{
+    public override void Effect()
+    {
+        throw new System.NotImplementedException();
+    }
+}

--- a/Assets/FortressFableProject/Program/Scripts/FortressFableScene/FactoryFactory/TrainingFacility.cs.meta
+++ b/Assets/FortressFableProject/Program/Scripts/FortressFableScene/FactoryFactory/TrainingFacility.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7ce8535447d45a9469569feb17154bec
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
■やったこと
・ファイル追加
・施設自体を生成し、ゲームマネージャーに保存するクラス
・タイプごとに生成する施設を変えるクラス（FactoryManager）

■今後
・キャンプと兵舎はクラスのみ作成したため、処理を追加する必要がある

■建設側で呼んでほしいメソッド
・FactoryManagerのpublic GameObject FactoryBuilding(FacilityBase.FacilityType buildingType)
　施設を生成するメソッド　戻り値：GameObject 　※呼び出す側で位置設定する必要アリ